### PR TITLE
Add table mode & toggles for distribution view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,10 +59,9 @@ class App extends React.Component {
         />
         <br />
         <ViewSelector
-          metric = {this.state.metric}
-          channel = {this.state.channel}
-          version = {this.state.version}
-          data = {this.state.data}
+          activeMetric = {this.state.activeMetric}
+          onMetricChange = {this.onMetricChange}
+          metricOptions = {this.state.metricOptions}
         />
       </div>
     );

--- a/src/Components/DistributionView.js
+++ b/src/Components/DistributionView.js
@@ -1,5 +1,8 @@
 import React, {Component} from "react";
-import {Grid, Row, Col} from "react-bootstrap";
+import {Grid, Row, Col, Tab, Nav, NavItem} from "react-bootstrap";
+import {TableMode} from "./TableMode.js";
+import MetricsGraphics from "react-metrics-graphics";
+import 'metrics-graphics/dist/metricsgraphics.css';
 
 export class DistributionView extends Component {
   render() {
@@ -13,6 +16,39 @@ export class DistributionView extends Component {
             <div>Hover over a point on the graph to view a specific value.</div>
             <div>Or, switch to table mode below to see a list of all absolute values.</div>
           </Col>
+        </Row>
+        <Row>
+          <Tab.Container
+            defaultActiveKey="graph"
+            id="view-options"
+          >
+            <Row>
+              <Col>
+                <Nav bsStyle="pills" className="view-options">
+                  <NavItem eventKey="graph">Graph</NavItem>
+                  <NavItem eventKey="table">Table</NavItem>
+                </Nav>
+              </Col>
+              <Col>
+                <Tab.Content animation>
+                  <Tab.Pane eventKey="graph">
+                    <MetricsGraphics
+                      title={this.props.activeMetric}
+                      data={ [{'date':new Date('2014-11-01'),'value':12}, {'date':new Date('2014-11-02'),'value':18}] }
+                      width={600}
+                      height={250}
+                      x_label={this.props.activeMetric}
+                    />
+                  </Tab.Pane>
+                  <Tab.Pane eventKey="table">
+                    <TableMode
+                      activeMetric = {this.props.activeMetric}
+                    />
+                  </Tab.Pane>
+                </Tab.Content>
+              </Col>
+            </Row>
+          </Tab.Container>
         </Row>
       </Grid>
     )

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -16,14 +16,11 @@ export class Navigation extends React.Component {
             <NavItem>
               <i className="fas fa-link"></i> Get Shortlink
             </NavItem>
-            <NavItem target="_blank" href="https://github.com/mozilla/telemetry-dashboard/issues">
+            <NavItem href="https://github.com/mozilla/telemetry-dashboard/issues">
               <i className="fas fa-bug"></i> Report a Bug
             </NavItem>
-            <NavItem target="_blank" href="https://telemetry.mozilla.org/">
+            <NavItem href="https://telemetry.mozilla.org/">
               <i className="fas fa-home"></i> Telemetry Portal
-            </NavItem>
-            <NavItem target="_blank" href="https://telemetry.mozilla.org/new-pipeline/tutorial.html#HistogramDashboard">
-              <i className="far fa-question-circle"></i> Usage Tutorial
             </NavItem>
           </Nav>
         </Navbar.Collapse>

--- a/src/Components/TableMode.js
+++ b/src/Components/TableMode.js
@@ -1,0 +1,18 @@
+import React, {Component} from "react";
+import {Table} from "react-bootstrap";
+
+export class TableMode extends Component {
+  render() {
+    return (
+      <Table striped bordered condensed responsive>
+        <thead>
+          <tr>
+            <th>Start</th>
+            <th>End</th>
+            <th>{this.props.activeMetric}</th>
+          </tr>
+        </thead>
+      </Table>
+    )
+  }
+}

--- a/src/Components/ViewSelector.js
+++ b/src/Components/ViewSelector.js
@@ -22,7 +22,9 @@ export class ViewSelector extends Component {
           eventKey={"dist"}
           title={<span><i className="far fa-chart-bar"></i> Distribution</span>}
         >
-          <DistributionView />
+          <DistributionView
+            activeMetric = {this.props.activeMetric}
+          />
         </Tab>
         <Tab
           eventKey={"comp"}


### PR DESCRIPTION
@chutten this is a *rough* concept of how the table v graph mode could look in the distribution view. The graph is currently just using the dummy data from the react-metrics-graphics example.

I don't love the pill style of navigation button, but it is a lot simpler than using conditioning rendering and adding another element to the state object, which I _think_ would be necessary if we wanted to have the toggle-able button group (@openjck, I'd love to get your input on this, if you have a minute!). Still, I might back-track later on and see if I can't figure out how to do the button group instead. I think it would look a lot nicer, and I think that's what @georgf was hoping for.