### PR TITLE
add mean function, get current data function.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends React.Component {
       lastMedian: 315,
       activeMetric: "GC_MS",
       metricOptions: metricData,
-      activeVersion: "60",
+      activeVersion: "62",
       versionOptions: ["60", "61", "62"],
       activeChannel: "nightly",
       channelOptions: ["nightly", "beta", "dev edition", "release"],
@@ -56,15 +56,18 @@ class App extends React.Component {
   }
 
   getCurrentData = () => {
-    fetch("https://mozilla.github.io/mdv2/data/" + this.state.activeMetric + "_" + this.state.activeChannel + "_" + this.state.activeVersion + ".json")
+    fetch("https://mozilla.github.io/mdv2/data/"
+        + this.state.activeMetric + "_"
+        + this.state.activeChannel + "_"
+        + this.state.activeVersion + ".json")
       .then(response => response.json())
       .then(data => this.setState({currentData: data}));
   }
 
   getMean = () => {
-    let buckets = this.state.currentData.map(item => item.start);
+    let buckets = this.state.currentData.map(item => item.start)
+      .concat([this.getLastBucketUpper*()]);
     let values = this.state.currentData.map(item => item.count);
-    buckets = buckets.concat([this.getLastBucketUpper()]);
     let totalHits = 0,
         bucketHits = 0;
     let linearTerm = (buckets[buckets.length - 1] - buckets[buckets.length -2]) / 2;
@@ -72,7 +75,7 @@ class App extends React.Component {
     let useLinearBuckets = this.kind === "linear" || this.kind === "flag" || this.kind === "boolean" || this.kind === "enumerated";
     for (let i = 0; i < values.length; i++) {
       totalHits += values[i];
-      let centralX = useLinearBuckets ? buckets[i] + linearTerm : buckets[i] * exponentialFactor; // find the center of the current bucket
+      let centralX = useLinearBuckets ? buckets[i] + linearTerm : buckets[i] * exponentialFactor;
       bucketHits += values[i] * centralX;
     };
     return bucketHits / totalHits;

--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ class App extends React.Component {
 
   getMean = () => {
     let buckets = this.state.currentData.map(item => item.start)
-      .concat([this.getLastBucketUpper*()]);
+      .concat([this.getLastBucketUpper()]);
     let values = this.state.currentData.map(item => item.count);
     let totalHits = 0,
         bucketHits = 0;

--- a/src/Components/DistributionView.js
+++ b/src/Components/DistributionView.js
@@ -59,6 +59,9 @@ export class DistributionView extends Component {
             />
           }
         </Row>
+        <Row>
+          <p>Mean: {this.props.mean}</p>
+        </Row>
       </Grid>
     );
   }

--- a/src/Components/SummaryView.js
+++ b/src/Components/SummaryView.js
@@ -12,9 +12,9 @@ export class SummaryView extends Component {
         </Row>
         <Row>
           <h3>Median: {this.props.median}</h3>
-          <p>The median value for {this.props.activeMetric} is {this.props.median}.</p>
+          <p>The median value for {this.props.activeMetric} {this.props.activeChannel} {this.props.activeVersion} is {this.props.median}.</p>
           <h3>95th Percentile: {this.props.nfifthPercentile}</h3>
-          <p>The 95th percentile for {this.props.activeMetric} is {this.props.nfifthPercentile}.</p>
+          <p>The 95th percentile for {this.props.activeMetric} {this.props.activeChannel} {this.props.activeVersion} is {this.props.nfifthPercentile}.</p>
           <h3>
             {this.props.change > 0 &&
               <i className="fas fa-arrow-up"></i>

--- a/src/Components/ViewSelector.js
+++ b/src/Components/ViewSelector.js
@@ -33,6 +33,7 @@ export class ViewSelector extends Component {
             <DistributionView
               activeMetric = {this.props.activeMetric}
               currentData = {this.props.currentData}
+              mean = {this.props.mean}
             />
           </Tab>
           <Tab


### PR DESCRIPTION
@georgf in this PR, I have:

- added a `getMean` function to calculate the mean.
- added a display of the mean in the distribution view.
- added a `getCurrentData` function that retrieves data dynamically.

In the future (i.e. hopefully later this week), these functions will all update based on changes to the state (`activeMetric`, `activeChannel`, and `activeVersion`, specifically); however, as discussed, I am still working through the logistics of lifecycle methods. 🙂 

l am also working on a version of the math functions that receives a data property, so that we can specify if we'd like to use the current or previous version data; this will set us up to be able to calculate statistics from previous versions, as well as the % change of those statistics.