### PR TITLE
Distribution View Updates (previously: A few boolean options (previously: Stacked bar bool))

### DIFF
--- a/public/data/scalars_telemetry_os_shutting_down_nightly_60.json
+++ b/public/data/scalars_telemetry_os_shutting_down_nightly_60.json
@@ -1,0 +1,16 @@
+[
+  {
+    "start": 0,
+    "end": 1,
+    "label": "never",
+    "count": 5762,
+    "proportion": 0.785977356
+  },
+  {
+    "start": 1,
+    "end": 2,
+    "label": "always",
+    "count": 2,
+    "proportion": 0.000272814
+  }
+]

--- a/public/data/scalars_telemetry_os_shutting_down_nightly_61.json
+++ b/public/data/scalars_telemetry_os_shutting_down_nightly_61.json
@@ -1,0 +1,16 @@
+[
+  {
+    "start": 0,
+    "end": 1,
+    "label": "never",
+    "count": 2662,
+    "proportion": 0.85977356
+  },
+  {
+    "start": 1,
+    "end": 2,
+    "label": "always",
+    "count": 0,
+    "proportion": 0.00
+  }
+]

--- a/public/data/scalars_telemetry_os_shutting_down_nightly_62.json
+++ b/public/data/scalars_telemetry_os_shutting_down_nightly_62.json
@@ -1,0 +1,16 @@
+[
+  {
+    "start": 0,
+    "end": 1,
+    "label": "never",
+    "count": 7620,
+    "proportion": 0.5977356
+  },
+  {
+    "start": 1,
+    "end": 2,
+    "label": "always",
+    "count": 20,
+    "proportion": 0.001568874
+  }
+]

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -20,6 +20,35 @@ export class DistributionView extends Component {
       // values with more than four digits, show three sig figs and a suffix.
       return count < 1000 ? count : format(".3s")(count);
     };
+
+    this.makePlotly = (data) => {
+      let plotlyData = {
+        type: "bar",
+        x: [],
+        y: [],
+        text: [],
+        customdata: [],
+        hoverinfo: "y+text",
+      };
+
+      for (let {start, label, proportion, count, end} of data) {
+        let x;
+        let text;
+        if (label) {
+          x = label;
+          text = `${label} - ${this.formatCount(count)} clients`;
+        } else {
+          x = start;
+          text = `[${start}, ${end-1}) - ${this.formatCount(count)} clients`;
+        }
+        plotlyData.x.push(x);
+        plotlyData.text.push(text);
+        plotlyData.y.push(proportion);
+        plotlyData.customdata.push(count);
+      }
+
+      return plotlyData;
+    };
   }
 
   handleChange = (event) => {
@@ -40,31 +69,7 @@ export class DistributionView extends Component {
     let metric = this.props.dataStore.active.metric;
     let data = this.props.dataStore.active.data;
 
-    let plotlyData = {
-      name: metric,
-      type: "bar",
-      x: [],
-      y: [],
-      text: [],
-      customdata: [],
-      hoverinfo: "y+text",
-    };
-
-    for (let {start, label, proportion, count, end} of data) {
-      let x;
-      let text;
-      if (label) {
-        x = label;
-        text = `${label} - ${this.formatCount(count)} clients`;
-      } else {
-        x = start;
-        text = `[${start}, ${end-1}) - ${this.formatCount(count)} clients`;
-      }
-      plotlyData.x.push(x);
-      plotlyData.text.push(text);
-      plotlyData.y.push(proportion);
-      plotlyData.customdata.push(count);
-    }
+    let plotData = [this.makePlotly(data)];
 
     return (
       <Grid  className="distribution view" fluid>
@@ -90,7 +95,7 @@ export class DistributionView extends Component {
         <Row>
           {this.state.mode === "graph" &&
             <Plot
-              data={[plotlyData]}
+              data={plotData}
               layout={ {
                 type: "bar",
                 title: metric,

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -64,7 +64,7 @@ export class DistributionView extends Component {
     window.removeEventListener("resize", this.onResize);
   }
 
-  makeBooleanData = (metric, [never, always]) => {
+  makeBooleanData(metric, [never, always]) {
     const totalCount = Math.ceil(never.count / never.proportion);
     const sometimes = {
       start: 2,

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -85,7 +85,6 @@ export class DistributionView extends Component {
   }
 
   render() {
-    let mean = this.props.dataStore.mean.toFixed(2);
     let metric = this.props.dataStore.active.metric;
     let data = this.props.dataStore.active.data;
 
@@ -148,9 +147,6 @@ export class DistributionView extends Component {
               currentData = {data}
             />
           }
-        </Row>
-        <Row>
-          <p>Mean: {mean}</p>
         </Row>
       </Grid>
     );

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -70,7 +70,8 @@ export class DistributionView extends Component {
     let data = this.props.dataStore.active.data;
 
     const BOOL_MEASURES = [
-      'scalars_devtools_onboarding_is_devtools_user',
+      "scalars_devtools_onboarding_is_devtools_user",
+      "scalars_telemetry_os_shutting_down",
     ];
 
     let plotData;

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -73,48 +73,15 @@ export class DistributionView extends Component {
       count: totalCount - never.count - always.count,
       proportion: 1 - never.proportion - always.proportion,
     };
-    const sometimesTrue = {
-      start: 2,
-      end: 3,
-      label: "sometimes true",
-      count: totalCount - never.count,
-      proportion: 1 - never.proportion,
-    };
-    const sometimesFalse = {
-      start: 3,
-      end: null,
-      label: "sometimes false",
-      count: totalCount - always.count,
-      proportion: 1 - always.proportion,
-    };
 
-    const threeTraces = [never, always, sometimes].map(datum => {
+    const threeTraces = [always, sometimes, never].map(datum => {
       let plotDatum = this.makePlotly([datum]);
       plotDatum.name = datum.label;
-      plotDatum.x[0] = metric;
+      plotDatum.x[0] = "";
       return plotDatum;
     });
 
-    const twoTraces = [
-      {
-        ...this.makePlotly([never, always]),
-        x: ["false", "true"],
-        name: "always",
-        marker: {
-          color: "#ff7f0e", // plotly orange
-        },
-      },
-      {
-        ...this.makePlotly([sometimesTrue, sometimesFalse]),
-        x: ["true", "false"],
-        name: "sometimes",
-        marker: {
-          color: "#1f77b4", // plotly blue
-        },
-      },
-    ];
-
-    return {threeTraces, twoTraces};
+    return threeTraces;
   }
 
   render() {
@@ -128,14 +95,10 @@ export class DistributionView extends Component {
     ];
 
     let plotData;
-    let plotDataGrouped;
-    let plotDataStacked2;
     if (BOOL_MEASURES.includes(metric)) {
-      let {threeTraces, twoTraces} = this.makeBooleanData(metric, data);
-      plotData = threeTraces;
-      plotDataStacked2 = plotDataGrouped = twoTraces;
+      plotData = this.makeBooleanData(metric, data);
     } else {
-      plotData = plotDataGrouped = plotDataStacked2 = [this.makePlotly(data)];
+      plotData = [this.makePlotly(data)];
     }
 
     return (
@@ -167,7 +130,6 @@ export class DistributionView extends Component {
                 type: "bar",
                 title: metric,
                 width: this.state.plotWidth,
-                barmode: 'stack',
                 xaxis: {
                   type: "category",
                   title: metric,
@@ -186,46 +148,6 @@ export class DistributionView extends Component {
               currentData = {data}
             />
           }
-        </Row>
-        <Row>
-          <Plot
-            data={plotDataGrouped}
-            layout={ {
-              type: "bar",
-              title: metric,
-              width: this.state.plotWidth,
-              barmode: 'group',
-              xaxis: {
-                type: "category",
-                title: metric,
-              },
-              yaxis: {
-                title: "Proportion of Users",
-                hoverformat: ".3p",
-                tickformat: ".3p",
-              },
-            } }
-          />
-        </Row>
-        <Row>
-          <Plot
-            data={plotDataStacked2}
-            layout={ {
-              type: "bar",
-              title: metric,
-              width: this.state.plotWidth,
-              barmode: 'stack',
-              xaxis: {
-                type: "category",
-                title: metric,
-              },
-              yaxis: {
-                title: "Proportion of Users",
-                hoverformat: ".3p",
-                tickformat: ".3p",
-              },
-            } }
-          />
         </Row>
         <Row>
           <p>Mean: {mean}</p>

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -100,7 +100,7 @@ export class DistributionView extends Component {
       const trueCount = Math.ceil(data[0].count / data[0].proportion) - data[0].count;
       const trueProportion = ((1 - data[0].proportion) * 100).toFixed(2);
       extraMessage = (
-        <h4>Clients reporting true at least once for {metric}: {trueCount} ({trueProportion}%)</h4>
+        <p>{trueCount} users ({trueProportion}% of respondents) reported true at least once.</p>
       );
     } else {
       plotData = [this.makePlotly(data)];
@@ -113,7 +113,6 @@ export class DistributionView extends Component {
             <i className="fas fa-info-circle"></i> The distribution view displays the distribution of user outcomes as a histogram.
             <div>Hover over a point on the graph to view a specific value.</div>
             <div>Or, switch to table mode below to see a list of all absolute values.</div>
-            {extraMessage}
           </Col>
         </Row>
         <Row>
@@ -142,7 +141,7 @@ export class DistributionView extends Component {
                 },
                 yaxis: {
                   title: "Proportion of Users",
-                  hoverformat: ".3p",
+                  hoverformat: ".4p",
                   tickformat: ".3p",
                 },
               } }
@@ -154,6 +153,9 @@ export class DistributionView extends Component {
               currentData = {data}
             />
           }
+        </Row>
+        <Row>
+          {extraMessage}
         </Row>
       </Grid>
     );

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -94,8 +94,14 @@ export class DistributionView extends Component {
     ];
 
     let plotData;
+    let extraMessage;
     if (BOOL_MEASURES.includes(metric)) {
       plotData = this.makeBooleanData(metric, data);
+      const trueCount = Math.ceil(data[0].count / data[0].proportion) - data[0].count;
+      const trueProportion = ((1 - data[0].proportion) * 100).toFixed(2);
+      extraMessage = (
+        <h4>Clients reporting true at least once for {metric}: {trueCount} ({trueProportion}%)</h4>
+      );
     } else {
       plotData = [this.makePlotly(data)];
     }
@@ -107,6 +113,7 @@ export class DistributionView extends Component {
             <i className="fas fa-info-circle"></i> The distribution view displays the distribution of user outcomes as a histogram.
             <div>Hover over a point on the graph to view a specific value.</div>
             <div>Or, switch to table mode below to see a list of all absolute values.</div>
+            {extraMessage}
           </Col>
         </Row>
         <Row>

--- a/src/components/tablemode.jsx
+++ b/src/components/tablemode.jsx
@@ -2,7 +2,33 @@ import React, {Component} from "react";
 import {Table} from "react-bootstrap";
 
 export class TableMode extends Component {
-  render() {
+  renderLabel() {
+    return (
+      <div className="table-mode">
+        <h3>{this.props.activeMetric}</h3>
+        <Table striped bordered condensed>
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>Count</th>
+              <th>Proportion</th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.props.currentData.map( (data, index) =>
+              <tr key={index}>
+                <td>{data.label}</td>
+                <td>{data.count}</td>
+                <td>{data.proportion}</td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </div>
+    );
+  }
+
+  renderStartEnd() {
     return (
       <div className="table-mode">
         <h3>{this.props.activeMetric}</h3>
@@ -28,5 +54,13 @@ export class TableMode extends Component {
         </Table>
       </div>
     );
+  }
+
+  render() {
+    if (this.props.currentData[0] && this.props.currentData[0].label) {
+      return this.renderLabel();
+    } else {
+      return this.renderStartEnd();
+    }
   }
 }

--- a/src/metricdata.js
+++ b/src/metricdata.js
@@ -34,7 +34,8 @@ export class MetricData {
     return [
       "GC_MS",
       "HTTP_SCHEME_UPGRADE_TYPE",
-      "scalars_devtools_onboarding_is_devtools_user"
+      "scalars_devtools_onboarding_is_devtools_user",
+      "scalars_telemetry_os_shutting_down",
     ];
   }
 


### PR DESCRIPTION
While prototyping how bool probes might look I stumbled upon a fifth option: stacking into a single plot that sums to 100%.

I think it would display better horizontally, but `orientation: "h"`isn't working immediately (maybe it's because of my `yaxis/xaxis` `layout` customizations? Something to investigate.)

Live demo's not working so well due to a weird bug that's messing with the live-hosted portals