### PR TITLE
Comparison View: Allow comparing to things other than GC_MS nightly 61

### DIFF
--- a/src/components/comparisonview.jsx
+++ b/src/components/comparisonview.jsx
@@ -1,13 +1,16 @@
 import React, {Component} from "react";
 import {Grid, Row, Col, DropdownButton, MenuItem} from "react-bootstrap";
 import Plot from "react-plotly.js";
-import GC_MS_nightly_61 from "./../data/GC_MS_nightly_61";
+import {MetricData} from "../metricdata.js";
 
 export class ComparisonView extends Component {
   constructor(props) {
     super(props);
+    this.dataStore = new MetricData();
+    this.prevProps = {};
     this.state = {
       compareVersion: "61",
+      compareData: this.dataStore.active
     };
   }
 
@@ -19,6 +22,11 @@ export class ComparisonView extends Component {
     this.setState({compareVersion: event});
   }
 
+  async loadDataToState(metric, channel, version) {
+    await this.dataStore.loadDataFor(metric, channel, version);
+    this.setState({compareData: this.dataStore.active});
+  }
+
   componentDidMount() {
     window.addEventListener("resize", this.onResize);
     this.onResize();
@@ -28,20 +36,39 @@ export class ComparisonView extends Component {
     window.removeEventListener("resize", this.onResize);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const {metric, channel, version} = this.props.dataStore.active;
+    if (this.prevProps.metric !== metric ||
+      this.prevProps.channel !== channel ||
+      this.prevProps.version !== version ||
+      prevState.compareVersion !== this.state.compareVersion
+    ) {
+      this.loadDataToState(this.props.dataStore.active.metric, this.props.dataStore.active.channel, this.state.compareVersion);
+    }
+
+    this.prevProps = {
+      metric: prevProps.dataStore.active.metric,
+      channel: prevProps.dataStore.active.channel,
+      version: prevProps.dataStore.active.version
+    };
+  }
+
   render() {
-    if (this.props.dataStore.active.metric !== "GC_MS") {
+    const {metric, channel, version} = this.props.dataStore.active;
+    const COMPARABLE_MEASURES = [
+      "GC_MS",
+      "scalars_timestamps_first_paint",
+      "scalars_browser_engagement_tab_open_event_count",
+    ];
+    if (!COMPARABLE_MEASURES.includes(metric) || !this.state.compareData) {
       return (
-        <div>Cannot compare {this.props.dataStore.active.metric} to GC_MS</div>
+        <div>Comparison View is currenty not supported for <span className="metric-name">{this.props.dataStore.active.metric}</span></div>
       );
     }
 
-    let x1 = GC_MS_nightly_61.map(e => e.start);
-    let y1 = GC_MS_nightly_61.map(e => e.count);
+    let x1 = this.state.compareData.data.map(e => e.start);
+    let y1 = this.state.compareData.data.map(e => e.count);
     let y2 = this.props.dataStore.active.data.map(e => e.count);
-
-    const metricName = this.props.dataStore.active.metric;
-    const activeChannel = this.props.dataStore.active.channel;
-    const activeVersion = this.props.dataStore.active.version;
 
     return (
       <Grid  className="comparison view" fluid>
@@ -84,7 +111,7 @@ export class ComparisonView extends Component {
                   x: x1,
                   y: y1,
                   type: "bar",
-                  name: activeChannel + " " + this.state.compareVersion,
+                  name: channel + " " + this.state.compareVersion,
                   opacity: 0.5,
                   mode: "markers",
                 },
@@ -92,17 +119,17 @@ export class ComparisonView extends Component {
                   x: x1,
                   y: y2,
                   type: "bar",
-                  name: activeChannel + " " + activeVersion,
+                  name: channel + " " + version,
                   opacity: 0.6,
                   mode: "markers",
                 },
               ]}
               layout={{
                 barmode: "group",
-                title: metricName,
+                title: metric,
                 xaxis: {
                   type: "category",
-                  title: metricName,
+                  title: metric,
                 },
                 yaxis: {
                   title: "Number of Users",

--- a/src/components/comparisonview.jsx
+++ b/src/components/comparisonview.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import {Grid, Row, Col, DropdownButton, MenuItem} from "react-bootstrap";
-//import MetricsGraphics from "react-metrics-graphics";
 import Plot from "react-plotly.js";
 import GC_MS_nightly_61 from "./../data/GC_MS_nightly_61";
 
@@ -36,12 +35,6 @@ export class ComparisonView extends Component {
       );
     }
 
-    /*
-    let data = [
-      this.props.dataStore.active.data,
-      GC_MS_nightly_61
-    ];
-    */
     let x1 = GC_MS_nightly_61.map(e => e.start);
     let y1 = GC_MS_nightly_61.map(e => e.count);
     let y2 = this.props.dataStore.active.data.map(e => e.count);
@@ -83,62 +76,6 @@ export class ComparisonView extends Component {
             </div>
           </Col>
         </Row>
-        {/*
-        <Row>
-          <Col>
-            <MetricsGraphics
-              title={metricName}
-              data={data}
-              chart_type="line"
-              x_label={metricName}
-              y_label="Proportion of Users"
-              y_accessor="proportion"
-              x_accessor="start"
-              area={[true, true]}
-              x_scale_type= "log"
-              width= {this.state.plotWidth}
-            />
-          </Col>
-        </Row>
-        */}
-        {/*
-        <Row>
-          <Col>
-            <Plot
-              data={[
-                {
-                  x: x1,
-                  y: y1,
-                  type: "bar",
-                  name: activeChannel + " " + this.state.compareVersion,
-                  opacity: 0.5,
-                  mode: "markers",
-                },
-                {
-                  x: x1,
-                  y: y2,
-                  type: "bar",
-                  name: activeChannel + " " + activeVersion,
-                  opacity: 0.6,
-                  mode: "markers",
-                },
-              ]}
-              layout={{
-                barmode: "overlay",
-                title: metricName,
-                xaxis: {
-                  type: "category",
-                  title: metricName,
-                },
-                yaxis: {
-                  title: "Number of Users",
-                },
-                width: this.state.plotWidth,
-              }}
-            />
-          </Col>
-        </Row>
-        */}
         <Row>
           <Col>
             <Plot

--- a/src/components/distributionview.jsx
+++ b/src/components/distributionview.jsx
@@ -87,14 +87,8 @@ export class DistributionView extends Component {
     ];
 
     let plotData;
-    let extraMessage;
     if (BOOL_MEASURES.includes(metric)) {
       plotData = this.makeBooleanData(metric, data);
-      const trueCount = Math.ceil(data[0].count / data[0].proportion) - data[0].count;
-      const trueProportion = ((1 - data[0].proportion) * 100).toFixed(2);
-      extraMessage = (
-        <p>{trueCount} users ({trueProportion}% of respondents) reported true at least once.</p>
-      );
     } else {
       plotData = [this.makePlotly(data)];
     }
@@ -146,9 +140,6 @@ export class DistributionView extends Component {
               currentData = {data}
             />
           }
-        </Row>
-        <Row>
-          {extraMessage}
         </Row>
       </Grid>
     );


### PR DESCRIPTION
In order to leave MetricData mostly alone this necessitated ComparisonView having its own copy datastore to load the comparing data and induce the view to rerender when that completed.

This involved some react hackery to store the previous state locally since the global dataStore could mutate beneath react's notice, meaning I had an infinite `componentDidUpdate->loadData->setState->componentDidUpdate` loop