### PR TITLE
Bring Comparison View up to spec

### DIFF
--- a/src/components/barplot.jsx
+++ b/src/components/barplot.jsx
@@ -1,0 +1,118 @@
+import React, {Component} from "react";
+import Plot from "react-plotly.js";
+import {format} from "d3"
+
+function formatCount(count) {
+  // For values with fewer than four digits, just display the value.
+  // For values with more than four digits, show three sig fix and a suffix.
+  return count < 1000 ? '' + count : format(".3s")(count);
+}
+
+function makePlotly(channel, version, data) {
+  let plotlyData = {
+    type: "bar",
+    x: [],
+    y: [],
+    text: [],
+    name: `${channel} ${version}`,
+    hoverinfo: "y+text",
+  };
+
+  for (let {start, label, proportion, count, end} of data) {
+    let x;
+    let text;
+    if (label) {
+      x = label;
+      text = `${label} - ${formatCount(count)} users`;
+    } else {
+      x = start;
+      if (!end) {
+        text = `values at least ${start} - ${formatCount(count)} users`;
+      } else {
+        text = `values between ${start} and ${end - 1} - ${formatCount(count)} users`;
+      }
+    }
+    plotlyData.x.push(x);
+    plotlyData.text.push(text);
+    plotlyData.y.push(proportion);
+  }
+
+  return plotlyData;
+}
+
+function prepData({metric, channel, version, data}) {
+
+  let plotData = data;
+
+  const BOOL_MEASURES = [
+    "scalars_devtools_onboarding_is_devtools_user",
+    "scalars_telemetry_os_shutting_down",
+  ];
+
+  if (BOOL_MEASURES.includes(metric)) {
+    const [never, always] = data;
+    const totalCount = Math.ceil(never.count
+                                  ? never.count / never.proportion
+                                  : always.count / always.proportion);
+    const sometimes = {
+      start: 2,
+      end: null,
+      label: "sometimes",
+      count: totalCount - never.count - always.count,
+      proportion: 1 - never.proportion - always.proportion,
+    };
+    plotData = [always, sometimes, never];
+  }
+
+  return makePlotly(channel, version, plotData);
+}
+
+export class BarPlot extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      plotWidth: window.innerWidth,
+    };
+  }
+
+  onResize() {
+    this.setState({
+      plotWidth: 0.75 * window.innerWidth,
+    });
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.onResize);
+    this.onResize();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.onResize);
+  }
+
+  render() {
+    const {metric} = this.props.data[0];
+    const plotlyData = this.props.data.map(prepData);
+
+    let plotLayout = {
+      type: "bar",
+      title: metric,
+      width: this.state.plotWidth,
+      xaxis: {
+        type: "category",
+      },
+      yaxis: {
+        title: "Proportion of Users",
+        hoverformat: ".4p",
+        tickformat: ".3p",
+      },
+    };
+
+    return (
+      <Plot
+        data={plotlyData}
+        layout={plotLayout}
+      />
+    );
+  }
+}

--- a/src/components/comparisonview.jsx
+++ b/src/components/comparisonview.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import {Grid, Row, Col, DropdownButton, MenuItem} from "react-bootstrap";
-import Plot from "react-plotly.js";
 import {MetricData} from "../metricdata.js";
+import {BarPlot} from "./barplot.jsx";
 
 export class ComparisonView extends Component {
   constructor(props) {
@@ -14,10 +14,6 @@ export class ComparisonView extends Component {
     };
   }
 
-  onResize = () => {
-    this.setState({plotWidth: 0.75 * window.innerWidth});
-  };
-
   handleChange = (event) => {
     this.setState({compareVersion: event});
   }
@@ -25,15 +21,6 @@ export class ComparisonView extends Component {
   async loadDataToState(metric, channel, version) {
     await this.dataStore.loadDataFor(metric, channel, version);
     this.setState({compareData: this.dataStore.active});
-  }
-
-  componentDidMount() {
-    window.addEventListener("resize", this.onResize);
-    this.onResize();
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.onResize);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -54,7 +41,7 @@ export class ComparisonView extends Component {
   }
 
   render() {
-    const {metric, channel, version} = this.props.dataStore.active;
+    const {metric} = this.props.dataStore.active;
     const COMPARABLE_MEASURES = [
       "GC_MS",
       "scalars_timestamps_first_paint",
@@ -65,10 +52,6 @@ export class ComparisonView extends Component {
         <div>Comparison View is currenty not supported for <span className="metric-name">{this.props.dataStore.active.metric}</span></div>
       );
     }
-
-    let x1 = this.state.compareData.data.map(e => e.start);
-    let y1 = this.state.compareData.data.map(e => e.count);
-    let y2 = this.props.dataStore.active.data.map(e => e.count);
 
     return (
       <Grid  className="comparison view" fluid>
@@ -104,40 +87,9 @@ export class ComparisonView extends Component {
           </Col>
         </Row>
         <Row>
-          <Col>
-            <Plot
-              data={[
-                {
-                  x: x1,
-                  y: y1,
-                  type: "bar",
-                  name: channel + " " + this.state.compareVersion,
-                  opacity: 0.5,
-                  mode: "markers",
-                },
-                {
-                  x: x1,
-                  y: y2,
-                  type: "bar",
-                  name: channel + " " + version,
-                  opacity: 0.6,
-                  mode: "markers",
-                },
-              ]}
-              layout={{
-                barmode: "group",
-                title: metric,
-                xaxis: {
-                  type: "category",
-                  title: metric,
-                },
-                yaxis: {
-                  title: "Number of Users",
-                },
-                width: this.state.plotWidth,
-              }}
-            />
-          </Col>
+          <BarPlot
+            data={[this.state.compareData, this.props.dataStore.active]}
+          />
         </Row>
       </Grid>
     );


### PR DESCRIPTION
This PR factors out our bar plot customizations and specializations into their own component (creatively named `BarPlot`) and then converts both Distribution and Comparison views to use it for a consistent plot experience.

Oh, and it enables comparing all the types of probes now, too. (Architecture!)

As before, live preview's here once [ci completes](https://travis-ci.org/chutten/mdv2/builds/428225676): https://chutten.github.io/mdv2/